### PR TITLE
Update calendar with admin mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# Calendrier des chambres
+# Calendrier du ménage de la cuisine
 
-Cette page permet de générer et d'imprimer un calendrier mensuel pour l'hôtel. Pour chaque jour, il est possible de saisir le numéro de la chambre occupée.
+Cette page permet de générer et d'imprimer un calendrier mensuel pour organiser le ménage de la cuisine.
+L'édition du calendrier est réservée à l'administrateur.
 
 - Les chambres vont de **1** à **54** mais la chambre **13** est exclue.
 - Le calendrier se génère entièrement côté client, aucun serveur n'est nécessaire.
@@ -9,5 +10,6 @@ Cette page permet de générer et d'imprimer un calendrier mensuel pour l'hôtel
 
 1. Ouvrez `index.html` dans votre navigateur.
 2. Sélectionnez le mois et l'année souhaités puis cliquez sur **Afficher**.
-3. Renseignez les numéros de chambre pour chaque date.
-4. Utilisez le bouton **Imprimer** pour obtenir la version papier du calendrier.
+3. Si vous devez modifier le calendrier, cliquez sur **Admin** et entrez le mot de passe `s00r1` pour activer le mode édition.
+4. Renseignez les numéros de chambre pour chaque date.
+5. Utilisez le bouton **Imprimer** pour obtenir la version papier du calendrier.

--- a/calendar.js
+++ b/calendar.js
@@ -4,6 +4,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const calendar = document.getElementById('calendar');
     const generateBtn = document.getElementById('generate');
     const printBtn = document.getElementById('print');
+    const subtitle = document.getElementById('subtitle');
+    const adminBtn = document.getElementById('admin-login');
+
+    let isAdmin = false;
 
     const monthNames = ['Janvier', 'Février', 'Mars', 'Avril', 'Mai', 'Juin', 'Juillet', 'Août', 'Septembre', 'Octobre', 'Novembre', 'Décembre'];
 
@@ -37,6 +41,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const year = parseInt(yearSelect.value, 10);
         calendar.innerHTML = '';
         createHeader();
+        if (subtitle) {
+            subtitle.textContent = `Pour le mois de ${monthNames[month]} ${year}`;
+        }
 
         let firstDay = new Date(year, month, 1).getDay();
         firstDay = firstDay === 0 ? 7 : firstDay; // start Monday
@@ -53,6 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
             input.min = 1;
             input.max = 54;
             input.placeholder = 'Chambre';
+            input.disabled = !isAdmin;
             input.addEventListener('input', function () {
                 if (this.value === '13') this.value = '';
             });
@@ -65,6 +73,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
     generateBtn.addEventListener('click', generateCalendar);
     printBtn.addEventListener('click', () => window.print());
+    if (adminBtn) {
+        adminBtn.addEventListener('click', () => {
+            const pass = prompt('Mot de passe admin ?');
+            if (pass === 's00r1') {
+                isAdmin = true;
+                alert('Mode \u00e9dition activ\u00e9');
+                generateCalendar();
+            } else {
+                alert('Mot de passe incorrect');
+            }
+        });
+    }
 
     generateCalendar();
 });

--- a/index.html
+++ b/index.html
@@ -3,16 +3,18 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Calendrier Chambres</title>
+    <title>Calendrier du ménage de la cuisine</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <h1>Calendrier mensuel des chambres</h1>
+    <h1>Calendrier du ménage de la cuisine</h1>
+    <h2 id="subtitle"></h2>
     <div class="controls">
         <select id="month"></select>
         <select id="year"></select>
         <button id="generate">Afficher</button>
         <button id="print">Imprimer</button>
+        <button id="admin-login">Admin</button>
     </div>
     <div id="calendar" class="calendar"></div>
     <script src="calendar.js"></script>


### PR DESCRIPTION
## Summary
- rename calendar to "Calendrier du ménage de la cuisine"
- show selected month in a subtitle
- add simple admin authentication to unlock editing
- document the new workflow

## Testing
- `npm test` *(fails: could not find package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68434252f9708324b5d054ce5849af5f