### PR TITLE
Add dynamic calendar updates on month/year change

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -71,6 +71,10 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    // Update calendar whenever the month or year selection changes
+    monthSelect.addEventListener('change', generateCalendar);
+    yearSelect.addEventListener('change', generateCalendar);
+
     generateBtn.addEventListener('click', generateCalendar);
     printBtn.addEventListener('click', () => window.print());
     if (adminBtn) {


### PR DESCRIPTION
## Summary
- trigger calendar generation when month or year dropdowns change

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684344ea60ac8324a527c3343739ff29