### PR TITLE
Enhance admin controls layout

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const printBtn = document.getElementById('print');
     const subtitle = document.getElementById('subtitle');
     const adminBtn = document.getElementById('admin-login');
+    const adminControls = document.getElementById('admin-controls');
     const startRoomInput = document.getElementById('start-room');
     const startDaySelect = document.getElementById('start-day');
     const autoAssignBtn = document.getElementById('auto-assign');
@@ -24,15 +25,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function updateAdminControls() {
-        if (startRoomInput) startRoomInput.style.display = isAdmin ? 'inline-block' : 'none';
-        if (startDaySelect) startDaySelect.style.display = isAdmin ? 'inline-block' : 'none';
-        if (autoAssignBtn) {
-            autoAssignBtn.style.display = isAdmin ? 'inline-block' : 'none';
-            autoAssignBtn.disabled = !isAdmin;
-        }
-        if (excludeRoomInput) excludeRoomInput.style.display = isAdmin ? 'inline-block' : 'none';
-        if (addExcludeBtn) addExcludeBtn.style.display = isAdmin ? 'inline-block' : 'none';
-        if (excludedListDiv) excludedListDiv.style.display = isAdmin ? 'inline-block' : 'none';
+        if (adminControls) adminControls.style.display = isAdmin ? 'flex' : 'none';
+        if (autoAssignBtn) autoAssignBtn.disabled = !isAdmin;
         updateExcludedList();
     }
 

--- a/index.html
+++ b/index.html
@@ -15,13 +15,15 @@
         <button id="generate">Afficher</button>
         <button id="print">Imprimer</button>
         <button id="theme-toggle">Thème</button>
-        <label for="start-room">Chambre de départ :</label>
-        <input id="start-room" type="number" min="1" max="54" placeholder="Chambre">
-        <select id="start-day"></select>
-        <button id="auto-assign">Auto</button>
-        <input id="exclude-room" type="number" min="1" max="54" placeholder="Exclure">
-        <button id="add-exclude">+</button>
-        <div id="excluded-list"></div>
+        <div id="admin-controls" class="admin-controls">
+            <label for="start-room">Chambre de départ :</label>
+            <input id="start-room" type="number" min="1" max="54" placeholder="Chambre">
+            <select id="start-day"></select>
+            <button id="auto-assign">Auto</button>
+            <input id="exclude-room" type="number" min="1" max="54" placeholder="Exclure">
+            <button id="add-exclude">+</button>
+            <div id="excluded-list"></div>
+        </div>
         <button id="admin-login">Admin</button>
     </div>
     <div id="calendar" class="calendar"></div>

--- a/styles.css
+++ b/styles.css
@@ -22,6 +22,7 @@ body.dark {
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
+    align-items: center;
 }
 
 .calendar {
@@ -51,17 +52,21 @@ input {
     align-self: center;
 }
 
-#start-room {
-    width: auto;
+#admin-controls {
+    display: none;
+    gap: 10px;
+    align-items: center;
 }
 
-#start-room,
-#start-day,
-#auto-assign,
-#exclude-room,
-#add-exclude,
+#admin-controls input,
+#admin-controls select,
+#admin-controls button {
+    width: 6em;
+}
+
 #excluded-list {
-    display: none;
+    min-width: 6em;
+    text-align: center;
 }
 
 @media print {


### PR DESCRIPTION
## Summary
- group admin-only UI elements in a dedicated container
- make admin inputs and buttons a consistent width
- align `.controls` items for a neater layout

## Testing
- `node --check calendar.js`

------
https://chatgpt.com/codex/tasks/task_e_68434af4abf08324bf616ceb1f275718