### PR TITLE
Remove manual calendar generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ L'édition du calendrier est réservée à l'administrateur.
 ## Utilisation
 
 1. Ouvrez `index.html` dans votre navigateur.
-2. Sélectionnez le mois et l'année souhaités puis cliquez sur **Afficher**.
+2. Sélectionnez le mois et l'année souhaités : le calendrier se met à jour automatiquement.
 3. Si vous devez modifier le calendrier, cliquez sur **Admin** et entrez le mot de passe `s00r1` pour activer le mode édition.
 4. Renseignez les numéros de chambre pour chaque date.
 5. Utilisez le bouton **Imprimer** pour obtenir la version papier du calendrier.

--- a/calendar.js
+++ b/calendar.js
@@ -2,7 +2,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const monthSelect = document.getElementById('month');
     const yearSelect = document.getElementById('year');
     const calendar = document.getElementById('calendar');
-    const generateBtn = document.getElementById('generate');
     const printBtn = document.getElementById('print');
     const subtitle = document.getElementById('subtitle');
     const adminBtn = document.getElementById('admin-login');
@@ -127,7 +126,6 @@ document.addEventListener('DOMContentLoaded', () => {
     monthSelect.addEventListener('change', generateCalendar);
     yearSelect.addEventListener('change', generateCalendar);
 
-    generateBtn.addEventListener('click', generateCalendar);
     printBtn.addEventListener('click', () => window.print());
     if (themeToggleBtn) {
         themeToggleBtn.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
     <div class="controls">
         <select id="month"></select>
         <select id="year"></select>
-        <button id="generate">Afficher</button>
         <button id="print">Imprimer</button>
         <button id="theme-toggle">Thème</button>
         <div id="admin-controls" class="admin-controls">


### PR DESCRIPTION
## Summary
- drop the "Afficher" button
- remove unused `generateBtn` listener
- explain automatic refresh in the README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68434cd82ed483248fb495fc8d8ac4db