### PR TITLE
Implement responsive design for mobile screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -81,3 +81,49 @@ input {
         border: none;
     }
 }
+
+@media (max-width: 600px) {
+    body {
+        margin: 10px;
+        font-size: 14px;
+    }
+
+    .controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .controls > * {
+        width: 100%;
+    }
+
+    .controls button,
+    .controls select,
+    .controls input {
+        font-size: 1rem;
+        padding: 10px;
+    }
+
+    #admin-controls {
+        flex-direction: column;
+    }
+
+    #admin-controls input,
+    #admin-controls select,
+    #admin-controls button {
+        width: 100%;
+    }
+
+    input {
+        width: 100%;
+    }
+
+    .calendar {
+        font-size: 0.9rem;
+        gap: 4px;
+    }
+
+    .day, .header {
+        padding: 8px;
+    }
+}


### PR DESCRIPTION
## Summary
- add media query for screens under 600px
- stack control elements vertically
- enlarge interactive elements for touch
- keep calendar cells legible on small screens

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68434e2b01b48324a099e452b0d311d1