### PR TITLE
Add start-day label and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
         <div id="admin-controls" class="admin-controls">
             <label for="start-room">Chambre de départ :</label>
             <input id="start-room" type="number" min="1" max="54" placeholder="Chambre">
+            <label for="start-day">Date de début :</label>
             <select id="start-day"></select>
             <button id="auto-assign">Auto</button>
             <label for="exclude-room">Chambre à exclure :</label>

--- a/styles.css
+++ b/styles.css
@@ -76,6 +76,10 @@ input {
     align-items: center;
 }
 
+#admin-controls label {
+    display: inline-block;
+}
+
 #admin-controls input,
 #admin-controls select,
 #admin-controls button {


### PR DESCRIPTION
## Summary
- add missing label for start-day selector
- style admin labels inline with controls

## Testing
- `node calendar.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68435169ef1c83248747c29a194466e7