### PR TITLE
Wrap admin controls section

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const subtitle = document.getElementById('subtitle');
     const adminBtn = document.getElementById('admin-login');
     const adminControls = document.getElementById('admin-controls');
+    const adminSection = document.querySelector('.admin-section');
     const startRoomInput = document.getElementById('start-room');
     const startDaySelect = document.getElementById('start-day');
     const autoAssignBtn = document.getElementById('auto-assign');
@@ -24,6 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function updateAdminControls() {
+        if (adminSection) adminSection.style.display = isAdmin ? 'block' : 'none';
         if (adminControls) adminControls.style.display = isAdmin ? 'flex' : 'none';
         if (excludedListDiv) excludedListDiv.style.display = isAdmin ? 'block' : 'none';
         if (autoAssignBtn) autoAssignBtn.disabled = !isAdmin;

--- a/index.html
+++ b/index.html
@@ -14,16 +14,18 @@
         <select id="year"></select>
         <button id="print">Imprimer</button>
         <button id="theme-toggle">Thème</button>
-        <div id="admin-controls" class="admin-controls">
-            <label for="start-room">Chambre de départ :</label>
-            <input id="start-room" type="number" min="1" max="54" placeholder="Chambre">
-            <label for="start-day">Date de début :</label>
-            <select id="start-day"></select>
-            <button id="auto-assign">Auto</button>
-            <label for="exclude-room">Chambre à exclure :</label>
-            <input id="exclude-room" type="number" min="1" max="54" placeholder="Exclure">
-            <button id="add-exclude">+</button>
-            <div id="excluded-list"></div>
+        <div class="admin-section">
+            <div id="admin-controls" class="admin-controls">
+                <label for="start-room">Chambre de départ :</label>
+                <input id="start-room" type="number" min="1" max="54" placeholder="Chambre">
+                <label for="start-day">Date de début :</label>
+                <select id="start-day"></select>
+                <button id="auto-assign">Auto</button>
+                <label for="exclude-room">Chambre à exclure :</label>
+                <input id="exclude-room" type="number" min="1" max="54" placeholder="Exclure">
+                <button id="add-exclude">+</button>
+                <div id="excluded-list"></div>
+            </div>
         </div>
         <button id="admin-login">Admin</button>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -70,6 +70,15 @@ input {
     align-self: center;
 }
 
+.admin-section {
+    display: none;
+    margin-top: 10px;
+    padding: 10px;
+    border: 1px solid var(--header-bg);
+    background-color: var(--header-bg);
+    border-radius: 4px;
+}
+
 #admin-controls {
     display: none;
     gap: 10px;


### PR DESCRIPTION
## Summary
- nest admin controls inside a new `.admin-section` container
- style `.admin-section` with margin, padding, border and background
- ensure calendar.js toggles this new container when admin mode is enabled

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_6843525838708324800ea2c13d959b88