### PR TITLE
Apply dark theme input styling and hide exclusion list on print

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -36,6 +36,10 @@ body.dark {
     --btn-add: #ffca28;
 }
 
+body.dark input {
+    color: #fff;
+}
+
 .controls {
     margin-bottom: 10px;
     display: flex;
@@ -108,6 +112,8 @@ button:hover {
 input {
     width: 80%;
     padding: 4px;
+    background-color: var(--bg-color);
+    color: var(--text-color);
 }
 
 .room-input {
@@ -198,6 +204,9 @@ input {
         display: none;
     }
     .controls input {
+        display: none;
+    }
+    #excluded-list {
         display: none;
     }
     input {


### PR DESCRIPTION
## Summary
- ensure calendar input fields match dark theme colors
- hide the exclusion list in the print stylesheet

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684361e95308832489b449f56e6031a2