### PR TITLE
Integrate emoji theme switcher

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -14,15 +14,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const addExcludeBtn = document.getElementById('add-exclude');
     const excludedListDiv = document.getElementById('excluded-list');
     const errorMessageDiv = document.getElementById('error-message');
-    const themeToggleBtn = document.getElementById('theme-toggle');
+    const themeSwitcher = document.getElementById('themeSwitcher');
 
     let isAdmin = false;
     const excludedRooms = new Set([13]);
 
-    const savedTheme = localStorage.getItem('theme');
-    if (savedTheme === 'dark') {
-        document.body.classList.add('dark');
-    }
 
     function updateExcludedList() {
         if (!excludedListDiv) return;
@@ -179,11 +175,23 @@ document.addEventListener('DOMContentLoaded', () => {
     yearSelect.addEventListener('change', generateCalendar);
 
     printBtn.addEventListener('click', () => window.print());
-    if (themeToggleBtn) {
-        themeToggleBtn.addEventListener('click', () => {
+    if (themeSwitcher) {
+        if (
+            localStorage.getItem('theme') === 'dark' ||
+            (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches && !localStorage.getItem('theme'))
+        ) {
+            document.body.classList.add('dark');
+            themeSwitcher.textContent = '☀️';
+        }
+        themeSwitcher.addEventListener('click', () => {
             document.body.classList.toggle('dark');
-            const theme = document.body.classList.contains('dark') ? 'dark' : 'light';
-            localStorage.setItem('theme', theme);
+            if (document.body.classList.contains('dark')) {
+                themeSwitcher.textContent = '☀️';
+                localStorage.setItem('theme', 'dark');
+            } else {
+                themeSwitcher.textContent = '🌘';
+                localStorage.setItem('theme', 'light');
+            }
         });
     }
     if (autoAssignBtn) {

--- a/index.html
+++ b/index.html
@@ -7,13 +7,13 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <button id="themeSwitcher" class="theme-switcher" title="Changer de thème">🌘</button>
     <h1>Calendrier du ménage de la cuisine</h1>
     <h2 id="subtitle"></h2>
     <div class="controls">
         <select id="month"></select>
         <select id="year"></select>
         <button id="print">Imprimer</button>
-        <button id="theme-toggle">Thème</button>
         <div class="admin-section">
             <div id="admin-controls" class="admin-controls">
                 <label for="start-room">Chambre de départ :</label>

--- a/styles.css
+++ b/styles.css
@@ -74,8 +74,30 @@ button:hover {
     color: #fff;
 }
 
-#theme-toggle {
-    background-color: var(--btn-theme);
+
+.theme-switcher {
+    position: fixed;
+    top: 22px;
+    right: 22px;
+    z-index: 9999;
+    background: var(--header-bg);
+    color: var(--text-color);
+    border: none;
+    font-size: 2em;
+    border-radius: 50%;
+    width: 48px;
+    height: 48px;
+    box-shadow: 0 2px 12px #0003;
+    cursor: pointer;
+    transition: background 0.17s, color 0.17s;
+    text-align: center;
+    line-height: 48px;
+    padding: 0;
+    vertical-align: middle;
+}
+
+.theme-switcher:hover {
+    background: var(--accent-color);
     color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- add emoji theme switcher button like in the cvlm project
- implement matching JavaScript logic
- style the button with CSS and remove the old theme toggle

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684362f2d53c83248cb9f3f1c285f77f