### PR TITLE
Hide theme switcher on print

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -245,6 +245,9 @@ input {
     .calendar {
         width: 100%;
     }
+    .theme-switcher {
+        display: none;
+    }
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- ensure the theme switcher button is hidden when printing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684407a0a2148324a29b4c3c895106eb