### PR TITLE
Add admin logout confirmation

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -15,6 +15,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const excludedListDiv = document.getElementById('excluded-list');
     const errorMessageDiv = document.getElementById('error-message');
     const themeSwitcher = document.getElementById('themeSwitcher');
+    const logoutModal = document.getElementById('logout-modal');
+    const logoutConfirm = document.getElementById('logout-confirm');
+    const logoutCancel = document.getElementById('logout-cancel');
 
     let isAdmin = false;
     const excludedRooms = new Set([13]);
@@ -43,6 +46,13 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    function setDayInputsDisabled(disabled) {
+        const inputs = calendar.querySelectorAll('.day input');
+        inputs.forEach(inp => {
+            inp.disabled = disabled;
+        });
+    }
+
     function updateAdminControls() {
         if (adminSection) adminSection.style.display = isAdmin ? 'block' : 'none';
         if (adminControls) adminControls.style.display = isAdmin ? 'flex' : 'none';
@@ -52,6 +62,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!isAdmin) errorMessageDiv.textContent = '';
         }
         if (autoAssignBtn) autoAssignBtn.disabled = !isAdmin;
+        setDayInputsDisabled(!isAdmin);
         updateExcludedList();
     }
 
@@ -209,6 +220,10 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if (adminBtn) {
         adminBtn.addEventListener('click', () => {
+            if (isAdmin) {
+                if (logoutModal) logoutModal.style.display = 'flex';
+                return;
+            }
             const pass = prompt('Mot de passe admin ?');
             if (pass === 's00r1') {
                 isAdmin = true;
@@ -218,6 +233,20 @@ document.addEventListener('DOMContentLoaded', () => {
             } else {
                 alert('Mot de passe incorrect');
             }
+        });
+    }
+
+    if (logoutCancel) {
+        logoutCancel.addEventListener('click', () => {
+            if (logoutModal) logoutModal.style.display = 'none';
+        });
+    }
+
+    if (logoutConfirm) {
+        logoutConfirm.addEventListener('click', () => {
+            isAdmin = false;
+            if (logoutModal) logoutModal.style.display = 'none';
+            updateAdminControls();
         });
     }
 

--- a/index.html
+++ b/index.html
@@ -31,6 +31,15 @@
         <button id="admin-login">Admin</button>
     </div>
     <div id="calendar" class="calendar"></div>
+    <div id="logout-modal" class="modal">
+        <div class="modal-content">
+            <p>Quitter le mode admin ?</p>
+            <div class="modal-buttons">
+                <button id="logout-confirm">Oui</button>
+                <button id="logout-cancel">Non</button>
+            </div>
+        </div>
+    </div>
     <script src="calendar.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -225,6 +225,39 @@ input {
     padding: 0 4px;
 }
 
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.6);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background: var(--bg-color);
+    color: var(--text-color);
+    padding: 20px;
+    border-radius: 4px;
+    text-align: center;
+    box-shadow: 0 2px 10px #0008;
+}
+
+.modal-buttons {
+    margin-top: 10px;
+    display: flex;
+    gap: 10px;
+    justify-content: center;
+}
+
+.modal-buttons button {
+    flex: 1 0 auto;
+}
+
 @media print {
     .controls button,
     .controls select {


### PR DESCRIPTION
## Summary
- add logout confirmation modal to exit admin mode
- disable inputs when leaving admin
- style modal window

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68440b1c14888324820630326f10dbbf