### PR TITLE
Use full weekday names in calendar header

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -85,7 +85,16 @@ document.addEventListener('DOMContentLoaded', () => {
     yearSelect.value = today.getFullYear();
 
     function createHeader() {
-        ['Lun', 'Mar', 'Mer', 'Jeu', 'Ven', 'Sam', 'Dim'].forEach(day => {
+        const fullDayNames = [
+            'Lundi',
+            'Mardi',
+            'Mercredi',
+            'Jeudi',
+            'Vendredi',
+            'Samedi',
+            'Dimanche',
+        ];
+        fullDayNames.forEach(day => {
             const div = document.createElement('div');
             div.className = 'header';
             div.textContent = day;


### PR DESCRIPTION
## Summary
- display full French weekday names at the top of the calendar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684411db33008324893ca6107ec71eb3