### PR TITLE
Déplacer le bouton Imprimer en bas

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
     <div class="controls">
         <select id="month"></select>
         <select id="year"></select>
-        <button id="print">Imprimer</button>
         <div class="admin-section">
             <div id="admin-controls" class="admin-controls">
                 <label for="start-room">Chambre de départ :</label>
@@ -31,6 +30,7 @@
         <button id="admin-login">Admin</button>
     </div>
     <div id="calendar" class="calendar"></div>
+    <button id="print">Imprimer</button>
     <div id="logout-modal" class="modal">
         <div class="modal-content">
             <p>Quitter le mode admin ?</p>

--- a/styles.css
+++ b/styles.css
@@ -72,6 +72,8 @@ button:hover {
 #print {
     background-color: var(--btn-print);
     color: #fff;
+    display: block;
+    margin: 10px auto;
 }
 
 
@@ -278,6 +280,7 @@ input {
     .calendar {
         width: 100%;
     }
+    #print,
     .theme-switcher {
         display: none;
     }


### PR DESCRIPTION
## Summary
- place the `Imprimer` button below the calendar
- adjust layout so the button is centered and hidden when printing

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68441302cbf883249a9591a7936f0d11