### PR TITLE
Add clear button for admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ L'édition du calendrier est réservée à l'administrateur.
 2. Sélectionnez le mois et l'année souhaités : le calendrier se met à jour automatiquement.
 3. Si vous devez modifier le calendrier, cliquez sur **Admin** et entrez le mot de passe `s00r1` pour activer le mode édition.
 4. Renseignez les numéros de chambre pour chaque date.
-5. Utilisez le bouton **Imprimer** pour obtenir la version papier du calendrier.
+5. Si besoin, utilisez le bouton **Clear** pour vider toutes les cases du calendrier.
+6. Utilisez le bouton **Imprimer** pour obtenir la version papier du calendrier.
 
 ## Mode administrateur
 
@@ -32,6 +33,10 @@ cliquez sur **Auto** pour préremplir les cases.
 Si certaines chambres ne doivent pas être planifiées, saisissez leur numéro dans
 l'entrée d'exclusion et cliquez sur le bouton **+**. Ces chambres seront ignorées
 lors de l'attribution automatique.
+
+## Nettoyer le calendrier
+
+Le bouton **Clear** efface toutes les valeurs saisies dans le calendrier pour repartir sur une grille vide.
 
 ## Thème sombre
 

--- a/calendar.js
+++ b/calendar.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const startRoomInput = document.getElementById('start-room');
     const startDaySelect = document.getElementById('start-day');
     const autoAssignBtn = document.getElementById('auto-assign');
+    const clearCalendarBtn = document.getElementById('clear-calendar');
     const excludeRoomInput = document.getElementById('exclude-room');
     const addExcludeBtn = document.getElementById('add-exclude');
     const excludedListDiv = document.getElementById('excluded-list');
@@ -62,6 +63,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!isAdmin) errorMessageDiv.textContent = '';
         }
         if (autoAssignBtn) autoAssignBtn.disabled = !isAdmin;
+        if (clearCalendarBtn) clearCalendarBtn.disabled = !isAdmin;
         setDayInputsDisabled(!isAdmin);
         updateExcludedList();
     }
@@ -192,6 +194,13 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    function clearCalendar() {
+        const dayInputs = calendar.querySelectorAll('.day input');
+        dayInputs.forEach(inp => {
+            inp.value = '';
+        });
+    }
+
     // Update calendar whenever the month or year selection changes
     monthSelect.addEventListener('change', generateCalendar);
     yearSelect.addEventListener('change', generateCalendar);
@@ -218,6 +227,9 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     if (autoAssignBtn) {
         autoAssignBtn.addEventListener('click', autoAssign);
+    }
+    if (clearCalendarBtn) {
+        clearCalendarBtn.addEventListener('click', clearCalendar);
     }
     if (addExcludeBtn) {
         addExcludeBtn.addEventListener('click', () => {

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
                 <button id="add-exclude">+</button>
                 <div id="excluded-list"></div>
                 <button id="auto-assign">Auto</button>
+                <button id="clear-calendar">Clear</button>
             </div>
             <div id="error-message" class="error-message"></div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -118,6 +118,11 @@ button:hover {
     color: #000;
 }
 
+#clear-calendar {
+    background-color: var(--btn-add);
+    color: #000;
+}
+
 .calendar {
     display: grid;
     grid-template-columns: repeat(7, 1fr);


### PR DESCRIPTION
## Summary
- add a **Clear** button in the admin controls
- enable/disable the button with admin mode
- implement `clearCalendar` JavaScript handler
- document usage of the Clear button

## Testing
- `node --check calendar.js`


------
https://chatgpt.com/codex/tasks/task_e_68441399ee5483248a84245ba65e2df3