### PR TITLE
Add Enter key support for room exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ cliquez sur **Auto** pour préremplir les cases.
 ## Exclure des chambres
 
 Si certaines chambres ne doivent pas être planifiées, saisissez leur numéro dans
-l'entrée d'exclusion et cliquez sur le bouton **+**. Ces chambres seront ignorées
-lors de l'attribution automatique.
+l'entrée d'exclusion puis appuyez sur **Enter** ou cliquez sur le bouton **+**.
+Ces chambres seront ignorées lors de l'attribution automatique.
 
 ## Nettoyer le calendrier
 

--- a/calendar.js
+++ b/calendar.js
@@ -201,6 +201,15 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    function addExcludedRoom() {
+        const num = parseInt(excludeRoomInput.value, 10);
+        if (!isNaN(num) && num >= 1 && num <= 54 && num !== 13) {
+            excludedRooms.add(num);
+            updateExcludedList();
+        }
+        excludeRoomInput.value = '';
+    }
+
     // Update calendar whenever the month or year selection changes
     monthSelect.addEventListener('change', generateCalendar);
     yearSelect.addEventListener('change', generateCalendar);
@@ -232,13 +241,14 @@ document.addEventListener('DOMContentLoaded', () => {
         clearCalendarBtn.addEventListener('click', clearCalendar);
     }
     if (addExcludeBtn) {
-        addExcludeBtn.addEventListener('click', () => {
-            const num = parseInt(excludeRoomInput.value, 10);
-            if (!isNaN(num) && num >= 1 && num <= 54 && num !== 13) {
-                excludedRooms.add(num);
-                updateExcludedList();
+        addExcludeBtn.addEventListener('click', addExcludedRoom);
+    }
+    if (excludeRoomInput) {
+        excludeRoomInput.addEventListener('keydown', e => {
+            if (e.key === 'Enter') {
+                e.preventDefault();
+                addExcludedRoom();
             }
-            excludeRoomInput.value = '';
         });
     }
     if (adminBtn) {


### PR DESCRIPTION
## Summary
- add `addExcludedRoom` helper in `calendar.js`
- allow pressing **Enter** or clicking **+** to exclude rooms
- document Enter key usage in README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684415657f8083249a1d1f4f43fbb20f