### PR TITLE
Hide admin section in print

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -273,6 +273,9 @@ input {
     .controls input {
         display: none;
     }
+    .admin-section {
+        display: none;
+    }
     #excluded-list {
         display: none;
     }


### PR DESCRIPTION
## Summary
- hide admin-section when printing so it doesn't show up on the calendar printout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684417f51f688324bccb7b5e21f5974d