### PR TITLE
Hide admin interface when printing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -273,8 +273,14 @@ input {
     .controls input {
         display: none;
     }
+    .admin-section {
+        display: none !important;
+    }
     #excluded-list {
-        display: none;
+        display: none !important;
+    }
+    .modal {
+        display: none !important;
     }
     input {
         border: none;


### PR DESCRIPTION
## Summary
- ensure admin section and excluded list are hidden even when toggled with inline style
- also hide the logout modal during print

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684417f51f688324bccb7b5e21f5974d