### PR TITLE
Fix printing to preserve input values

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -265,6 +265,13 @@ document.addEventListener('DOMContentLoaded', () => {
         excludeRoomInput.value = '';
     }
 
+    function restoreInputs(values) {
+        const inputs = calendar.querySelectorAll('.day input');
+        inputs.forEach((input, i) => {
+            input.value = values[i] || '';
+        });
+    }
+
     function applyLanguage(lang) {
         currentLang = lang;
         document.documentElement.lang = lang;
@@ -294,9 +301,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
     printBtn.addEventListener('click', () => {
         const before = currentLang;
+        const savedValues = Array.from(calendar.querySelectorAll('.day input')).map(inp => inp.value);
         if (before !== 'fr') {
             applyLanguage('fr');
-            window.addEventListener('afterprint', () => applyLanguage(before), { once: true });
+            restoreInputs(savedValues);
+            window.addEventListener(
+                'afterprint',
+                () => {
+                    applyLanguage(before);
+                    restoreInputs(savedValues);
+                },
+                { once: true }
+            );
         }
         window.print();
     });


### PR DESCRIPTION
## Summary
- preserve all day input values when switching languages for print
- restore inputs after language change using helper

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68442477a470832491c5e4ae1998e5d6