### PR TITLE
Add API key example comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ npx serve .
 ```
 
 Si vous souhaitez conserver les affectations, modifiez `BIN_URL` dans `calendar.js` et renseignez votre clé API dans `localStorage` (clé `jsonbin_api_key`) ou via un `<script data-api-key>`.
+Un exemple commenté est présent dans `index.html` juste avant l'inclusion du script `calendar.js` :
+
+```html
+<!-- <script data-api-key="VOTRE_CLÉ_API"></script> -->
+```
 
 ## Utilisation rapide
 

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
             </div>
         </div>
     </div>
+    <!-- <script data-api-key="VOTRE_CLÉ_API"></script> -->
     <script src="calendar.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- demonstrate how to provide an API key via HTML
- mention the example in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844a947e44c83249d90cee69aff16b6