### PR TITLE
Improve error reporting when saving assignments

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -36,13 +36,22 @@ document.addEventListener('DOMContentLoaded', () => {
             if (!found && chambre) assignments.push({date, chambre});
 
             // 3. Met à jour le bin entier (PUT)
-            await fetch(BIN_URL, {
+            const response = await fetch(BIN_URL, {
                 method: "PUT",
                 headers: {
                     "Content-Type": "application/json"
                 },
                 body: JSON.stringify(assignments)
             });
+
+            // Check server response and display any error details
+            const ct = response.headers.get('content-type') || '';
+            const text = ct.includes('application/json') ?
+                JSON.stringify(await response.json()) : await response.text();
+
+            if (!response.ok) {
+                showRequestError(text);
+            }
         } catch (err) {
             console.error(err);
             showRequestError("Erreur lors de l'enregistrement des données");


### PR DESCRIPTION
## Summary
- inspect the server response in `saveAssignment`
- display error details with `showRequestError` if the PUT request fails

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6844bf798cd08324b6f17d9e2c992a47