### PR TITLE
Gérer CORS dans le proxy JSONBin

### DIFF
--- a/api/jsonbin-proxy/[[...path]].js
+++ b/api/jsonbin-proxy/[[...path]].js
@@ -6,6 +6,14 @@ const BIN_ID = process.env.JSONBIN_ID || '6844456c8561e97a5020ae90';
 const BASE_URL = `https://api.jsonbin.io/v3/b/${BIN_ID}`;
 
 module.exports = async function(req, res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    return res.status(204).end();
+  }
+
   const apiKey = process.env.JSONBIN_KEY;
   if (!apiKey) {
     return res.status(500).json({ error: 'JSONBIN_KEY not set' });


### PR DESCRIPTION
## Notes
- Aucun test automatisé n'existe, `npm test` échoue comme prévu.

## Résumé
- Ajout des en-têtes `Access-Control-Allow-*` dans `api/jsonbin-proxy/[[...path]].js`
- Réponse dédiée aux requêtes `OPTIONS` avec le statut 204


------
https://chatgpt.com/codex/tasks/task_e_684732238a288324b6b0da7a13eb444e