### PR TITLE
Ajout d'une clé API configurable pour JSONBin

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Si vous souhaitez conserver les affectations, déployez la fonction `api/jsonbin
 
 Cette fonction contient un identifiant de bin fixé dans la constante `BIN_ID`. Remplacez cette valeur par l'identifiant de votre propre bin ou exposez-le via la variable `JSONBIN_ID` lors du déploiement. La clé `JSONBIN_KEY` doit correspondre à ce même bin.
 
+La clé utilisée est définie dans la constante `API_KEY` avec la valeur par défaut `'votre_cle_test'`. Pensez à remplacer cette valeur par votre clé réelle ou à fournir `JSONBIN_KEY` via les variables d'environnement au moment du déploiement.
+
 Le front-end utilise alors automatiquement `/api/jsonbin-proxy` pour communiquer avec JSONBin.
 
 La variable `JSONBIN_KEY` doit impérativement correspondre à la *Master Key* de votre bin JSONBin, disponible depuis le tableau de bord du service.

--- a/api/jsonbin-proxy/[[...path]].js
+++ b/api/jsonbin-proxy/[[...path]].js
@@ -3,6 +3,7 @@ const fetch = require('node-fetch');
 // Default bin used for local testing. Replace with your own bin ID or
 // set the JSONBIN_ID environment variable when deploying.
 const BIN_ID = process.env.JSONBIN_ID || '6844456c8561e97a5020ae90';
+const API_KEY = process.env.JSONBIN_KEY || 'votre_cle_test';
 const BASE_URL = `https://api.jsonbin.io/v3/b/${BIN_ID}`;
 
 module.exports = async function(req, res) {
@@ -14,7 +15,7 @@ module.exports = async function(req, res) {
     return res.status(204).end();
   }
 
-  const apiKey = process.env.JSONBIN_KEY;
+  const apiKey = API_KEY;
   if (!apiKey) {
     return res.status(500).json({ error: 'JSONBIN_KEY not set' });
   }


### PR DESCRIPTION
## Summary
- ajouter la constante `API_KEY` dans `jsonbin-proxy`
- utiliser cette constante lors des appels à JSONBin
- documenter la clé par défaut dans le README

## Testing
- `npm test` *(échoue : no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684735719f0c8324a857ce80a57fb33f