### PR TITLE
Ajuste mise en page mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -378,8 +378,16 @@ input {
     .controls button,
     .controls select,
     .controls input {
-        font-size: 1.1rem;
+        font-size: 1rem;
         padding: 10px;
+    }
+
+    button {
+        font-size: 0.9rem;
+    }
+
+    .room-prefix {
+        font-size: 0.75rem;
     }
 
     #admin-controls {
@@ -411,7 +419,7 @@ input {
     }
 
     .room-input input {
-        width: 100%;
+        width: 3.5em;
     }
 
     .calendar {


### PR DESCRIPTION
## Notes
- `npm test` échoue car aucun test n'est défini.

## Summary
- réduit la taille du texte des boutons et de `.room-prefix` sur petit écran
- fixe la largeur des champs de saisie de chambre pour éviter les débordements


------
https://chatgpt.com/codex/tasks/task_e_6849ba8a821c8324ab49f9c4e1dc4b01