### PR TITLE
Refactorisation en modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,9 +64,7 @@
             <button type="button" class="add-room">+</button>
         </div>
     </template>
-    <!-- SUPABASE SDK -->
-    <!-- SUPABASE SDK EN PREMIER !!! -->
-    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
-    <script src="calendar.js"></script>
+    <!-- Chargement des modules en ES modules -->
+    <script type="module" src="calendar.js"></script>
 </body>
 </html>

--- a/supabase.js
+++ b/supabase.js
@@ -1,0 +1,69 @@
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
+
+const SUPABASE_URL = 'https://dexbvustuzzghzdpetjr.supabase.co';
+const SUPABASE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRleGJ2dXN0dXp6Z2h6ZHBldGpyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk1NjQ4NTEsImV4cCI6MjA2NTE0MDg1MX0.h3PbDOoiLj9gQmaGJkRWZL7vN_M52Qboik4EFjqpavA';
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+export async function fetchAssignments() {
+  const { data, error } = await supabase
+    .from('assignments')
+    .select('*');
+  if (error) throw new Error(error.message);
+  return data.map(row => ({
+    date: row.due_date.slice(0, 10),
+    chambres: row.title ? row.title.split('/').map(s => s.trim()).filter(Boolean) : [],
+  }));
+}
+
+export async function saveAssignments(assignments) {
+  if (assignments.length === 0) return;
+  const month = assignments[0].date.slice(0, 7);
+  const { data: exist, error: errExist } = await supabase
+    .from('assignments')
+    .select('id, due_date');
+  if (errExist) throw new Error(errExist.message);
+  const toDelete = exist
+    .filter(a => a.due_date.slice(0, 7) === month)
+    .map(a => a.id);
+  if (toDelete.length) {
+    const { error: errDel } = await supabase
+      .from('assignments')
+      .delete()
+      .in('id', toDelete);
+    if (errDel) throw new Error(errDel.message);
+  }
+  const cleanAssignments = assignments
+    .filter(a => a.chambre && a.chambre !== '')
+    .map(a => ({ title: a.chambre, due_date: a.date }));
+  if (cleanAssignments.length) {
+    const { error: errInsert } = await supabase
+      .from('assignments')
+      .insert(cleanAssignments);
+    if (errInsert) throw new Error(errInsert.message);
+  }
+}
+
+export async function saveAssignment(date, chambre) {
+  if (chambre) {
+    const { error } = await supabase
+      .from('assignments')
+      .upsert({ title: chambre, due_date: date }, { onConflict: ['due_date'] });
+    if (error) throw new Error(error.message);
+  } else {
+    const { error } = await supabase
+      .from('assignments')
+      .delete()
+      .eq('due_date', date);
+    if (error) throw new Error(error.message);
+  }
+}
+
+export async function deleteAssignments(dates) {
+  if (!dates.length) return;
+  const { error } = await supabase
+    .from('assignments')
+    .delete()
+    .in('due_date', dates);
+  if (error) throw new Error(error.message);
+}

--- a/ui.js
+++ b/ui.js
@@ -1,0 +1,8 @@
+export function showRequestError(msg) {
+  const errorMessageDiv = document.getElementById('error-message');
+  if (errorMessageDiv) {
+    errorMessageDiv.textContent = msg;
+  } else {
+    alert(msg);
+  }
+}


### PR DESCRIPTION
## Notes
- Les fonctions Supabase sont déplacées dans `supabase.js` et utilisent l'ESM CDN.
- `showRequestError` est désormais dans `ui.js`.
- `calendar.js` importe ces modules et gère les erreurs avec `try/catch`.
- `index.html` charge maintenant le script principal en mode module.

## Tests
- `npm test` *(échoue : no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849c70a8fc083249223c9f8a0c61989