### PR TITLE
Ajout suivi des chambres dans autoAssign

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -313,11 +313,14 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         let room = startRoom;
+        const visited = new Set();
         const updates = [];
         for (let i = startDay - 1; i < dayDivs.length; i++) {
-            while (excludedRooms.has(room)) {
+            let safety = 0;
+            while (excludedRooms.has(room) || visited.has(room)) {
                 room++;
                 if (room > 54) room = 1;
+                if (++safety > 54) break;
             }
             const wrapper = dayDivs[i].querySelector('.room-input');
             const inputs = wrapper.querySelectorAll('input');
@@ -331,9 +334,12 @@ document.addEventListener('DOMContentLoaded', () => {
             const rooms = [room];
             if (linkedRooms.has(room)) {
                 linkedRooms.get(room).forEach(r => {
-                    if (!excludedRooms.has(r) && !rooms.includes(r)) rooms.push(r);
+                    if (!excludedRooms.has(r) && !visited.has(r) && !rooms.includes(r)) {
+                        rooms.push(r);
+                    }
                 });
             }
+            rooms.forEach(r => visited.add(r));
             if (inputs.length) {
                 inputs[0].value = rooms.join(' / ');
             }


### PR DESCRIPTION
## Notes
- exécution de `npm test` échoue car aucun test n'est défini.

## Summary
- ajoute une structure `visited` pour mémoriser les chambres déjà assignées
- ignore les chambres déjà visitées lors de la répartition automatique
- marque aussi les chambres liées et enregistre le résultat dans Supabase

------
https://chatgpt.com/codex/tasks/task_e_6849cf2eae6883248e51f18f7b2214b5