### PR TITLE
Fix allow multiple room numbers

### DIFF
--- a/calendar.js
+++ b/calendar.js
@@ -191,7 +191,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function createRoomInput(day) {
         const input = document.createElement('input');
-        input.type = 'number';
+        input.type = 'text';
+        input.inputMode = 'numeric';
         input.min = 1;
         input.max = 54;
         input.placeholder = texts[currentLang].dayPrefix;

--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
     <template id="room-input-template">
         <div class="room-input">
             <span class="room-prefix"></span>
-            <input type="number" min="1" max="54" placeholder="#">
+            <input type="text" min="1" max="54" placeholder="#">
             <button type="button" class="add-room">+</button>
         </div>
     </template>


### PR DESCRIPTION
## Summary
- switch template input for rooms to `type="text"`
- set inputs for room numbers to text mode and use numeric inputMode

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node calendar.js` *(fails to run as ES module)*

------
https://chatgpt.com/codex/tasks/task_e_6849d7bcfd9c8324a6da24187ae100a0