### PR TITLE
Ajout de script de tests API

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,5 +66,6 @@
     </template>
     <!-- Chargement des modules en ES modules -->
     <script type="module" src="calendar.js"></script>
+    <script type="module" src="test-api.js"></script>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -269,9 +269,25 @@ input {
 }
 
 .error-message {
-    color: red;
     margin-top: 4px;
     text-align: center;
+}
+
+.error-item {
+    color: red;
+    margin: 2px 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.error-close {
+    background: none;
+    border: none;
+    color: red;
+    cursor: pointer;
+    font-size: 1em;
+    line-height: 1;
 }
 
 .excluded-item {

--- a/test-api.js
+++ b/test-api.js
@@ -1,0 +1,65 @@
+import { fetchAssignments, saveAssignment, deleteAssignments } from './supabase.js';
+import { showRequestError } from './ui.js';
+
+async function runTest(title, fn) {
+  try {
+    await fn();
+  } catch (err) {
+    showRequestError(`${title}: ${err.message}`);
+  }
+}
+
+async function runTests() {
+  const today = new Date();
+  const date = new Date(today.getFullYear(), today.getMonth(), today.getDate() + 1)
+    .toISOString()
+    .slice(0, 10);
+
+  await runTest('Nettoyage initial', async () => {
+    await deleteAssignments([date]);
+  });
+
+  await runTest('Écriture', async () => {
+    await saveAssignment(date, '101');
+    const all = await fetchAssignments();
+    if (!all.some(a => a.date === date && a.chambres.includes('101'))) {
+      throw new Error('valeur non retrouvée après écriture');
+    }
+  });
+
+  await runTest('Lecture', async () => {
+    const all = await fetchAssignments();
+    if (!all.some(a => a.date === date)) {
+      throw new Error('enregistrement introuvable');
+    }
+  });
+
+  await runTest('Modification', async () => {
+    await saveAssignment(date, '102');
+    const all = await fetchAssignments();
+    const record = all.find(a => a.date === date);
+    if (!record || !record.chambres.includes('102')) {
+      throw new Error('modification non enregistrée');
+    }
+  });
+
+  await runTest('Écriture double', async () => {
+    await saveAssignment(date, '201');
+    await saveAssignment(date, '202');
+    const all = await fetchAssignments();
+    const matches = all.filter(a => a.date === date);
+    if (matches.length !== 1 || matches[0].chambres.length !== 1 || matches[0].chambres[0] !== '202') {
+      throw new Error('conflit sur la même date');
+    }
+  });
+
+  await runTest('Effacement', async () => {
+    await deleteAssignments([date]);
+    const all = await fetchAssignments();
+    if (all.some(a => a.date === date)) {
+      throw new Error('enregistrement non supprimé');
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', runTests);

--- a/ui.js
+++ b/ui.js
@@ -1,7 +1,18 @@
 export function showRequestError(msg) {
   const errorMessageDiv = document.getElementById('error-message');
   if (errorMessageDiv) {
-    errorMessageDiv.textContent = msg;
+    const item = document.createElement('div');
+    item.className = 'error-item';
+    const label = document.createElement('span');
+    label.textContent = msg;
+    const close = document.createElement('button');
+    close.type = 'button';
+    close.textContent = '×';
+    close.className = 'error-close';
+    close.addEventListener('click', () => item.remove());
+    item.appendChild(label);
+    item.appendChild(close);
+    errorMessageDiv.appendChild(item);
   } else {
     alert(msg);
   }


### PR DESCRIPTION
## Notes
- Mise en place d'un fichier `test-api.js` exécuté dans le navigateur
- `showRequestError` gère désormais une liste de messages fermables
- Ajustement du style pour les erreurs accumulées
- Chargement du test via `index.html`

## Testing
- `npm test` *(échoue : Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849d983986c8324967eba3e6b4c7338