### PR TITLE
Ajout d'une page dev pour test-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ node testSupabase.js
 
 Les donnees recuperees ou un message d'erreur complet s'afficheront dans la console.
 
+### Tests manuels de l'API
+
+Un autre script (`test-api.js`) permet de verifier depuis le navigateur que les requetes
+Supabase fonctionnent correctement. Ouvrez la page `dev.html` pour executer ces tests
+manuels. Les resultats ou erreurs s'afficheront directement sur l'interface.
+
 
 ### Thème sombre
 

--- a/dev.html
+++ b/dev.html
@@ -67,5 +67,6 @@
     <!-- Chargement des modules en ES modules -->
     <script src="env-loader.js"></script>
     <script type="module" src="calendar.js"></script>
+    <script type="module" src="test-api.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Notes
- npm test échoue car aucun test n'est défini.

## Summary
- suppression de l'inclusion de `test-api.js` dans `index.html`
- ajout de `dev.html` pour exécuter `test-api.js`
- documentation de cette page de test dans le README


------
https://chatgpt.com/codex/tasks/task_e_6849df53db648324bb9d78ba4cb3051c