### PR TITLE
Ajout répertoire généré au gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.log
 node_modules/
 .env
+dist/


### PR DESCRIPTION
## Notes
- Ajout de `dist/` à `.gitignore` pour ignorer les fichiers générés ainsi que le fichier `.env` déjà présent.
- Aucune donnée sensible n'est suivie par Git.

## Tests
- `npm test` *(échoue : Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849e1a15e7c83248f7985c703de482b