### PR TITLE
Ajout du script start et mise à jour des README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ Aucune installation spécifique n'est requise. Clonez le dépôt puis ouvrez le 
 
 ```bash
 npx serve .
+# ou
+npm start
 ```
+
+Le script `npm start` lance automatiquement `npx serve .` pour servir l'application.
 
 ### Configuration
 

--- a/README_ar.md
+++ b/README_ar.md
@@ -21,7 +21,11 @@
 
 ```bash
 npx serve .
+# أو
+npm start
 ```
+
+الأمر `npm start` يشغّل تلقائيًا `npx serve .` لخدمة التطبيق محليًا.
 
 ### الإعداد
 

--- a/README_en.md
+++ b/README_en.md
@@ -21,7 +21,11 @@ No specific installation is required. Clone the repository and open the `index.h
 
 ```bash
 npx serve .
+# or
+npm start
 ```
+
+The `npm start` command automatically runs `npx serve .` to serve the application.
 
 ### Configuration
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Cette application web gère la répartition des tâches de ménage dans la cuisine. Elle fonctionne entièrement côté client : ouvrez simplement `index.html` dans un navigateur moderne pour générer et imprimer un calendrier personnalisé.",
   "main": "src/calendar.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "npx serve ."
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Notes
- aucune

## Summary
- ajout du script npm `start` pour lancer `npx serve .`
- mention de ce script dans chaque README pour un démarrage rapide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aa16dfb28832498281e9f08611d91