### PR TITLE
Simplifie le test API via index.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,9 @@ Les donnees recuperees ou un message d'erreur complet s'afficheront dans la cons
 ### Tests manuels de l'API
 
 Un autre script (`test-api.js`) permet de verifier depuis le navigateur que les requetes
-Supabase fonctionnent correctement. Ouvrez la page `dev.html` pour executer ces tests
-manuels. Les resultats ou erreurs s'afficheront directement sur l'interface.
+Supabase fonctionnent correctement. Ouvrez la page `index.html?test-api=1` (ou
+simplement `dev.html`) pour executer ces tests manuels. Les resultats ou erreurs
+s'afficheront directement sur l'interface.
 
 
 ### Thème sombre

--- a/dev.html
+++ b/dev.html
@@ -1,72 +1,13 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Calendrier du ménage de la cuisine</title>
-    <link rel="stylesheet" href="styles.css">
+  <meta charset="UTF-8">
+  <title>Dev</title>
+  <script>
+    window.location.href = 'index.html?test-api=1';
+  </script>
 </head>
 <body>
-    <button id="langSwitcher" class="lang-switcher" title="Changer de langue">AR</button>
-    <button id="themeSwitcher" class="theme-switcher" title="Changer de thème">🌘</button>
-    <h1>Calendrier du ménage de la cuisine</h1>
-    <h2 id="subtitle"></h2>
-    <div class="controls">
-        <div class="date-selectors">
-            <select id="month"></select>
-            <select id="year"></select>
-        </div>
-        <button id="admin-login">Admin</button>
-    </div>
-
-    <div class="admin-section">
-        <div id="admin-controls" class="admin-controls">
-            <div class="admin-group">
-                <label for="start-room">Départ&nbsp;:</label>
-                <input id="start-room" type="number" min="1" max="54" placeholder="#">
-                <label for="start-day">Jour&nbsp;:</label>
-                <select id="start-day"></select>
-            </div>
-            <div class="admin-group">
-                <label for="exclude-room">Exclure&nbsp;:</label>
-                <input id="exclude-room" type="number" min="1" max="54" placeholder="#">
-                <button id="add-exclude">+</button>
-                <div id="excluded-list"></div>
-            </div>
-            <div class="admin-group" id="link-group">
-                <input id="link-room-a" type="number" min="1" max="54" placeholder="#">
-                <input id="link-room-b" type="number" min="1" max="54" placeholder="#">
-                <button id="add-link">Lier</button>
-                <div id="linked-list"></div>
-            </div>
-            <div class="admin-buttons">
-                <button id="auto-assign">Auto</button>
-                <button id="clear-calendar">Vider</button>
-            </div>
-        </div>
-        <div id="error-message" class="error-message"></div>
-    </div>
-    <div id="calendar" class="calendar"></div>
-    <button id="print">Imprimer</button>
-    <div id="logout-modal" class="modal">
-        <div class="modal-content">
-            <p>Quitter le mode admin ?</p>
-            <div class="modal-buttons">
-                <button id="logout-confirm">Oui</button>
-                <button id="logout-cancel">Non</button>
-            </div>
-        </div>
-    </div>
-    <template id="room-input-template">
-        <div class="room-input">
-            <span class="room-prefix"></span>
-            <input type="text" min="1" max="54" placeholder="#">
-            <button type="button" class="add-room">+</button>
-        </div>
-    </template>
-    <!-- Chargement des modules en ES modules -->
-    <script src="env-loader.js"></script>
-    <script type="module" src="src/calendar.js"></script>
-    <script type="module" src="test-api.js"></script>
+  <p>Redirection...</p>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -67,5 +67,16 @@
     <!-- Chargement des modules en ES modules -->
     <script src="env-loader.js"></script>
     <script type="module" src="src/calendar.js"></script>
+    <script>
+      (function() {
+        const params = new URLSearchParams(window.location.search);
+        if (params.has('test-api')) {
+          const s = document.createElement('script');
+          s.type = 'module';
+          s.src = 'test-api.js';
+          document.head.appendChild(s);
+        }
+      })();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Notes
- `index.html` charge maintenant `test-api.js` seulement quand l'URL contient `?test-api=1`.
- `dev.html` se contente de rediriger vers `index.html` avec ce paramètre.
- La documentation explique comment lancer ces tests.

## Tests
- `npm test` *(échoue : « no test specified »)*

------
https://chatgpt.com/codex/tasks/task_e_684aa2823e2083248ca828c4eb7f9d32