### PR TITLE
Ajout du titre pour les options auto

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
     </div>
 
     <div class="admin-section">
+        <h3 id="auto-options-title"></h3>
         <div id="admin-controls" class="admin-controls">
             <div class="admin-group">
                 <label for="start-room">No de chambre de départ</label>

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -24,6 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const subtitle = document.getElementById('subtitle');
     const adminBtn = document.getElementById('admin-login');
     const adminControls = document.getElementById('admin-controls');
+    const autoOptionsTitle = document.getElementById('auto-options-title');
     const adminSection = document.querySelector('.admin-section');
     const startRoomInput = document.getElementById('start-room');
     const startDaySelect = document.getElementById('start-day');
@@ -82,6 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
             adminPassPrompt: 'Mot de passe admin ?',
             adminEnabled: 'Mode édition activé',
             adminWrongPass: 'Mot de passe incorrect',
+            adminSectionTitle: 'Options automatiques',
             dayPrefix: 'Chambre',
         },
         ar: {
@@ -105,6 +107,7 @@ document.addEventListener('DOMContentLoaded', () => {
             adminPassPrompt: 'كلمة مرور الإدارة؟',
             adminEnabled: 'تم تفعيل وضع التحرير',
             adminWrongPass: 'كلمة المرور غير صحيحة',
+            adminSectionTitle: 'إعدادات التوزيع التلقائي',
             dayPrefix: 'الغرفة',
         },
     };
@@ -120,6 +123,7 @@ document.addEventListener('DOMContentLoaded', () => {
             autoAssignBtn,
             clearCalendarBtn,
             adminBtn,
+            autoOptionsTitle,
             printBtn,
             logoutModal,
             logoutConfirm,

--- a/src/ui.js
+++ b/src/ui.js
@@ -37,6 +37,7 @@ export function applyLanguage(lang, {
   autoAssignBtn,
   clearCalendarBtn,
   adminBtn,
+  autoOptionsTitle,
   printBtn,
   logoutModal,
   logoutConfirm,
@@ -59,6 +60,7 @@ export function applyLanguage(lang, {
   autoAssignBtn.textContent = t.autoAssign;
   clearCalendarBtn.textContent = t.clearCalendar;
   adminBtn.textContent = t.adminLogin;
+  if (autoOptionsTitle) autoOptionsTitle.textContent = t.adminSectionTitle;
   printBtn.textContent = t.print;
   if (logoutModal) logoutModal.querySelector('p').textContent = t.logoutPrompt;
   logoutConfirm.textContent = t.logoutConfirm;


### PR DESCRIPTION
## Notes
- Ajout d'un nouvel élément `<h3 id="auto-options-title">` dans *index.html*.
- Nouvelle clé `adminSectionTitle` dans les traductions (fr et ar).
- Passage du nouvel élément à `applyLanguage` et mise à jour de la fonction dans *ui.js*.
- L'exécution de `npm test` échoue car aucun test n'est défini.


------
https://chatgpt.com/codex/tasks/task_e_684ab09c6b608324a0eb3ef95ad1091d