### PR TITLE
Sélecteur pour la chambre de départ

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
         <div id="admin-controls" class="admin-controls">
             <div class="admin-group">
                 <label for="start-room">No de chambre de départ</label>
-                <input id="start-room" type="number" min="1" max="54" placeholder="#">
+                <select id="start-room"></select>
                 <label for="start-day">Jour&nbsp;:</label>
                 <select id="start-day"></select>
             </div>

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -134,6 +134,29 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    function updateRoomSelectOptions() {
+        if (!startRoomInput) return;
+        const prev = startRoomInput.value;
+        startRoomInput.innerHTML = '';
+        const linked = new Set();
+        linkedRooms.forEach((set, a) => {
+            linked.add(a);
+            set.forEach(b => linked.add(b));
+        });
+        for (let i = 1; i <= 54; i++) {
+            if (i === 13) continue;
+            if (excludedRooms.has(i)) continue;
+            if (linked.has(i)) continue;
+            const opt = document.createElement('option');
+            opt.value = i;
+            opt.textContent = i;
+            startRoomInput.appendChild(opt);
+        }
+        if (startRoomInput.querySelector(`option[value="${prev}"]`)) {
+            startRoomInput.value = prev;
+        }
+    }
+
     function updateExcludedList() {
         if (!excludedListDiv) return;
         const rooms = Array.from(excludedRooms).sort((a, b) => a - b);
@@ -157,6 +180,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
             excludedListDiv.appendChild(item);
         });
+        updateRoomSelectOptions();
     }
 
     function setDayInputsDisabled(disabled) {
@@ -475,6 +499,7 @@ document.addEventListener('DOMContentLoaded', () => {
             item.appendChild(btn);
             linkedListDiv.appendChild(item);
         });
+        updateRoomSelectOptions();
     }
 
 
@@ -629,4 +654,5 @@ document.addEventListener('DOMContentLoaded', () => {
     updateAdminControls();
     updateExcludedList();
     updateLinkedList();
+    updateRoomSelectOptions();
 });

--- a/src/ui.js
+++ b/src/ui.js
@@ -53,7 +53,6 @@ export function applyLanguage(lang, {
   document.querySelector('h1').textContent = t.title;
   const startRoomLabel = document.querySelector('label[for="start-room"]');
   if (startRoomLabel) startRoomLabel.textContent = t.startRoomLabel;
-  startRoomInput.placeholder = t.startRoomPlaceholder;
   document.querySelector('label[for="start-day"]').textContent = t.startDayLabel;
   document.querySelector('label[for="exclude-room"]').textContent = t.excludeRoomLabel;
   excludeRoomInput.placeholder = t.excludeRoomPlaceholder;


### PR DESCRIPTION
## Notes
- `npm test` échoue car aucun test n'est défini.

## Summary
- remplacement du champ de saisie de la chambre de départ par un menu déroulant
- ajout de la fonction `updateRoomSelectOptions()` pour peupler ce menu en excluant les numéros interdits et liés
- mise à jour de `updateExcludedList` et `updateLinkedList` pour rafraîchir la liste des chambres disponibles
- initialisation du menu lors du chargement
- nettoyage de la gestion de la langue pour le nouveau sélecteur

------
https://chatgpt.com/codex/tasks/task_e_684ab47d77fc8324bfefe655f4a41fea