### PR TITLE
Corrige la visibilité des numéros de chambre

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -269,6 +269,13 @@ input {
 .room-input input {
     width: 5em;
     margin: 2px 0;
+    font-weight: bold;
+    color: var(--text-color);
+}
+.room-input input:disabled {
+    color: var(--text-color);
+    -webkit-text-fill-color: var(--text-color);
+    opacity: 1;
 }
 
 .controls label {
@@ -537,6 +544,13 @@ input {
 
     .room-input input {
         width: 3.5em;
+        font-weight: bold;
+        color: var(--text-color);
+    }
+    .room-input input:disabled {
+        color: var(--text-color);
+        -webkit-text-fill-color: var(--text-color);
+        opacity: 1;
     }
 
     .calendar {


### PR DESCRIPTION
## Notes
- Exécuter `npm test` échoue car aucun test n'est défini.

## Summary
- renforce le style `.room-input input` pour mieux voir les numéros
- conserve la couleur du texte même quand les champs sont désactivés


------
https://chatgpt.com/codex/tasks/task_e_684ad21dccd08324b0603151d70526ba