### PR TITLE
Ajout d'un nettoyage du calendrier lors du téléchargement PDF

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -729,7 +729,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         const wrapper = document.createElement('div');
         wrapper.appendChild(header1);
         wrapper.appendChild(header2);
-        wrapper.appendChild(calendarEl.cloneNode(true));
+        const clone = calendarEl.cloneNode(true);
+        clone.querySelectorAll('.add-room').forEach(btn => btn.remove());
+        clone.querySelectorAll('input').forEach(inp => {
+            inp.disabled = true;
+        });
+        wrapper.appendChild(clone);
         const opt = {
             margin: 0,
             filename: 'calendrier.pdf',


### PR DESCRIPTION
## Notes
- `npm test` échoue car aucun test n'est défini.

## Résumé
- Suppression des boutons `.add-room` et désactivation des champs de saisie dans le clone utilisé pour la génération PDF.
- Le rendu PDF correspond désormais à l'interface non-admin.

------
https://chatgpt.com/codex/tasks/task_e_684ad874fed88324b6e956a88be9dec4