### PR TITLE
Mise à jour de l'exemple d'environnement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
+SUPABASE_URL=<votre_url>
+SUPABASE_KEY=<votre_cle>
 ADMIN_PASS=s00r1

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ Le script `npm start` lance automatiquement `npx serve .` pour servir l'applicat
 ### Configuration
 
 Copiez le fichier `.env.example` vers `.env` et renseignez `SUPABASE_URL`, `SUPABASE_KEY` ainsi que `ADMIN_PASS`.
+Le fichier `.env.example` contient par defaut :
+
+```env
+SUPABASE_URL=<votre_url>
+SUPABASE_KEY=<votre_cle>
+ADMIN_PASS=s00r1
+```
 
 Pour conserver les affectations avec Supabase :
 

--- a/README_ar.md
+++ b/README_ar.md
@@ -32,6 +32,13 @@ npm start
 ### الإعداد
 
 انسخ الملف `.env.example` إلى `.env` ثم عيّن القيم `SUPABASE_URL` و`SUPABASE_KEY` و`ADMIN_PASS`.
+يحتوي ملف `.env.example` على:
+
+```env
+SUPABASE_URL=<your_url>
+SUPABASE_KEY=<your_key>
+ADMIN_PASS=s00r1
+```
 
 للاحتفاظ بالتوزيعات على الإنترنت باستخدام Supabase:
 

--- a/README_en.md
+++ b/README_en.md
@@ -33,6 +33,13 @@ The `npm start` command automatically runs `npx serve .` to serve the applicatio
 ### Configuration
 
 Copy the `.env.example` file to `.env` and set `SUPABASE_URL`, `SUPABASE_KEY` and `ADMIN_PASS`.
+The `.env.example` file includes:
+
+```env
+SUPABASE_URL=<your_url>
+SUPABASE_KEY=<your_key>
+ADMIN_PASS=s00r1
+```
 
 To persist assignments with Supabase:
 


### PR DESCRIPTION
## Notes
- Ajout de `SUPABASE_URL` et `SUPABASE_KEY` dans `.env.example`
- Ajout d'exemples d'environnement dans les README (fr, en, ar)
- Lancement de `npm test` qui échoue faute de tests définis


------
https://chatgpt.com/codex/tasks/task_e_684adc76a1b48324a8c51d543ca31fcd