### PR TITLE
Mise à jour de la licence MIT

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "calendrier",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@supabase/supabase-js": "^2.50.0"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "type": "commonjs",
   "dependencies": {
     "@supabase/supabase-js": "^2.50.0"


### PR DESCRIPTION
## Résumé
- licence définie sur MIT dans package.json
- mise à jour cohérente du package-lock

## Tests
- `npm test` (échec prévu car aucun test spécifié)

------
https://chatgpt.com/codex/tasks/task_e_684af1f2d5e08324bb8fc11e49c4a530