### PR TITLE
Ajout catch sur génération PDF

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -781,6 +781,17 @@ document.addEventListener('DOMContentLoaded', async () => {
                     restoreInputs(calendar, savedValues);
                 }
                 if (darkBefore) document.body.classList.add('dark');
+            })
+            .catch(async (err) => {
+                if (document.body.contains(wrapper)) {
+                    document.body.removeChild(wrapper);
+                }
+                if (before !== 'fr') {
+                    await setLanguage(before);
+                    restoreInputs(calendar, savedValues);
+                }
+                if (darkBefore) document.body.classList.add('dark');
+                showRequestError(`Erreur generation PDF : ${err.message}`);
             });
     });
 


### PR DESCRIPTION
## Notes
- Impossible de tester la génération de PDF via l’interface faute de navigateur.

## Summary
- ajoute un gestionnaire d’erreur lors de la génération du PDF pour nettoyer le DOM et rétablir le thème et la langue

## Testing
- `npm test` *(échoue : no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c1a9f6f748324b0b7a689e220de4d