### PR TITLE
Corrige l'emplacement du wrapper pour l'impression

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -756,9 +756,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
         // Ajoute au DOM pour que les styles CSS s'appliquent (OBLIGATOIRE)
         wrapper.style.position = "fixed";
-        wrapper.style.left = "-9999px";
+        wrapper.style.left = "0";
         wrapper.style.top = "0";
         wrapper.style.zIndex = "-9999";
+        wrapper.style.opacity = "0";
         document.body.appendChild(wrapper);
 
         const opt = {
@@ -841,9 +842,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         wrapper.appendChild(clone);
 
         wrapper.style.position = "fixed";
-        wrapper.style.left = "-9999px";
+        wrapper.style.left = "0";
         wrapper.style.top = "0";
         wrapper.style.zIndex = "-9999";
+        wrapper.style.opacity = "0";
         document.body.appendChild(wrapper);
         calendarEl.style.display = 'none';
 


### PR DESCRIPTION
## Notes
- Les tests npm échouent car aucun test n'est défini.

## Summary
- garde le wrapper dans la zone imprimable pour la génération PDF
- même ajustement pour l'impression classique

------
https://chatgpt.com/codex/tasks/task_e_684c1c6799548324bd991bd0bd39dbe0