### PR TITLE
Assure la restauration après impression

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -863,7 +863,19 @@ document.addEventListener('DOMContentLoaded', async () => {
             { once: true }
         );
 
-        window.print();
+        try {
+            window.print();
+        } finally {
+            if (document.body.contains(wrapper)) {
+                document.body.removeChild(wrapper);
+            }
+            calendarEl.style.display = '';
+            if (before !== 'fr') {
+                await setLanguage(before);
+                restoreInputs(calendar, savedValues);
+            }
+            if (darkBefore) document.body.classList.add('dark');
+        }
     });
 
     initThemeSwitcher(themeSwitcher);


### PR DESCRIPTION
## Notes
- La fonction liée au clic sur le bouton d'impression utilisait `afterprint` pour restaurer l'état du calendrier.
- Un bloc `try`/`finally` entoure maintenant `window.print()` afin de garantir la suppression du `wrapper` et le rétablissement de l'affichage et du thème/langue même si l'événement `afterprint` ne se déclenche pas.

## Résultats des tests
- `npm test` *(échoue : « Error: no test specified »)*

------
https://chatgpt.com/codex/tasks/task_e_684c1cbd0a648324b1962f7007b968a8