### PR TITLE
Ajout classe print-clone et simplification wrapper

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -755,11 +755,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         wrapper.appendChild(clone);
 
         // Ajoute au DOM pour que les styles CSS s'appliquent (OBLIGATOIRE)
-        wrapper.style.position = "fixed";
-        wrapper.style.left = "0";
-        wrapper.style.top = "0";
-        wrapper.style.zIndex = "-9999";
-        wrapper.style.opacity = "0";
+        wrapper.className = 'print-clone';
         document.body.appendChild(wrapper);
 
         const opt = {
@@ -841,11 +837,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         clone.style.color = "#222";
         wrapper.appendChild(clone);
 
-        wrapper.style.position = "fixed";
-        wrapper.style.left = "0";
-        wrapper.style.top = "0";
-        wrapper.style.zIndex = "-9999";
-        wrapper.style.opacity = "0";
+        wrapper.className = 'print-clone';
         document.body.appendChild(wrapper);
         calendarEl.style.display = 'none';
 

--- a/styles.css
+++ b/styles.css
@@ -427,6 +427,18 @@ input {
     }
 }
 
+.print-clone {
+    position: fixed;
+    left: -9999px;
+    top: 0;
+}
+@media print {
+    .print-clone {
+        position: static;
+        left: 0;
+    }
+}
+
 /* Responsive mobile & calendrier overflow */
 @media (max-width: 700px) {
     .calendar {


### PR DESCRIPTION
## Notes
- Ajout d'une classe CSS pour gérer l'impression
- Utilisation de cette classe dans le script pour cacher puis afficher le clone lors de l'impression/export

## Testing
- `npm test` *(échoue: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c1e95e2e083248b6015ae24ce2708