### PR TITLE
Corrige l'affichage du wrapper pendant la génération PDF

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -757,6 +757,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         // Ajoute au DOM pour que les styles CSS s'appliquent (OBLIGATOIRE)
         wrapper.className = 'print-clone';
         document.body.appendChild(wrapper);
+        // Rend le wrapper visible pour la capture PDF
+        wrapper.style.position = 'static';
+        wrapper.style.left = '0';
+        wrapper.style.opacity = '1';
 
         const opt = {
             margin: 0,
@@ -770,7 +774,8 @@ document.addEventListener('DOMContentLoaded', async () => {
             .from(wrapper)
             .save()
             .then(async () => {
-                // Nettoyage : retire le wrapper du DOM, sinon ça s'accumule
+                // Nettoyage : rétablit la classe puis retire le wrapper
+                wrapper.className = 'print-clone';
                 document.body.removeChild(wrapper);
                 // Remet le thème/langue si besoin
                 if (before !== 'fr') {
@@ -781,6 +786,7 @@ document.addEventListener('DOMContentLoaded', async () => {
             })
             .catch(async (err) => {
                 if (document.body.contains(wrapper)) {
+                    wrapper.className = 'print-clone';
                     document.body.removeChild(wrapper);
                 }
                 if (before !== 'fr') {


### PR DESCRIPTION
## Notes
- exécution de `npm test` renvoie l'erreur prévue "no test specified".

## Summary
- rendu temporaire du wrapper visible avant l'appel à `html2pdf`
- remise de la classe `print-clone` puis suppression du wrapper une fois la promesse résolue ou rejetée

------
https://chatgpt.com/codex/tasks/task_e_684c1f736cb4832490c20146e9e5ec2d