### PR TITLE
Amélioration mise en page impression

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -755,8 +755,12 @@ document.addEventListener('DOMContentLoaded', async () => {
         clone.style.color = "#222";
         wrapper.appendChild(clone);
 
+        const fd = new Date(year, month, 1).getDay();
+        const weeksPdf = Math.ceil(((fd === 0 ? 7 : fd) - 1 + new Date(year, month + 1, 0).getDate()) / 7);
+
         // Ajoute au DOM pour que les styles CSS s'appliquent (OBLIGATOIRE)
         wrapper.className = 'print-clone';
+        if (weeksPdf >= 6) wrapper.classList.add('compact-print');
         document.body.appendChild(wrapper);
         // Rend le wrapper visible pour la capture PDF
         wrapper.style.position = 'static';
@@ -844,7 +848,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         clone.style.color = "#222";
         wrapper.appendChild(clone);
 
+        const fdP = new Date(year, month, 1).getDay();
+        const weeksPrint = Math.ceil(((fdP === 0 ? 7 : fdP) - 1 + new Date(year, month + 1, 0).getDate()) / 7);
+
         wrapper.className = 'print-clone';
+        if (weeksPrint >= 6) wrapper.classList.add('compact-print');
         document.body.appendChild(wrapper);
         calendarEl.style.display = 'none';
         if (mainTitle) mainTitle.style.display = 'none';

--- a/styles.css
+++ b/styles.css
@@ -425,6 +425,18 @@ input {
         background: #fff !important;
         color: #222 !important;
     }
+    .compact-print h1,
+    .compact-print h2 {
+        font-size: 1.3em !important;
+        margin-bottom: 8px !important;
+    }
+    .compact-print .calendar {
+        font-size: 1em !important;
+    }
+    .compact-print .day,
+    .compact-print .header {
+        padding: 6px !important;
+    }
 }
 
 .print-clone {


### PR DESCRIPTION
## Summary
- shrink calendar when month spans 6 weeks
- reduce header and cell spacing in print

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c26d8b94c8324a8975f8d3a05455a