### PR TITLE
Mise à jour titres admin multilingues

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     </div>
 
     <div class="admin-section">
-        <h3 class="admin-section-title">🛠️ Gestion de la configuration</h3>
+        <h3 id="config-title" class="admin-section-title">🛠️ Gestion de la configuration</h3>
         <div class="card">
             <div class="config-controls">
                 <select id="config-select"></select>
@@ -30,7 +30,7 @@
                 <button id="change-pass" title="Changer le mot de passe"><span class="icon">🔑</span> Passwd</button>
             </div>
         </div>
-        <h3 class="admin-section-title">🏠 Chambres & Départs</h3>
+        <h3 id="rooms-title" class="admin-section-title">🏠 Chambres & Départs</h3>
         <div class="card">
             <div class="admin-group">
                 <label for="start-room">No de chambre de départ</label>
@@ -39,7 +39,7 @@
                 <select id="start-day"></select>
             </div>
         </div>
-        <h3 class="admin-section-title">🚫 Exclusions</h3>
+        <h3 id="exclusions-title" class="admin-section-title">🚫 Exclusions</h3>
         <div class="card">
             <div class="admin-group">
                 <label for="exclude-room">Exclure :</label>
@@ -48,7 +48,7 @@
                 <div id="excluded-list"></div>
             </div>
         </div>
-        <h3 class="admin-section-title">🔗 Chambres liées</h3>
+        <h3 id="linked-rooms-title" class="admin-section-title">🔗 Chambres liées</h3>
         <div class="card">
             <div class="admin-group" id="link-group">
                 <select id="link-room-a"></select>

--- a/src/calendar.js
+++ b/src/calendar.js
@@ -33,6 +33,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     const adminBtn = document.getElementById('admin-login');
     const adminControls = document.getElementById('admin-controls');
     const autoOptionsTitle = document.getElementById('auto-options-title');
+    const configTitle = document.getElementById('config-title');
+    const roomsTitle = document.getElementById('rooms-title');
+    const exclusionsTitle = document.getElementById('exclusions-title');
     const linkedRoomsTitle = document.getElementById('linked-rooms-title');
     const adminSection = document.querySelector('.admin-section');
     const startRoomInput = document.getElementById('start-room');
@@ -98,6 +101,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             adminPassPrompt: 'Mot de passe admin ?',
             adminEnabled: 'Mode édition activé',
             adminWrongPass: 'Mot de passe incorrect',
+            configTitle: 'Gestion de la configuration',
+            roomsTitle: 'Chambres & Départs',
+            exclusionsTitle: 'Exclusions',
             adminSectionTitle: "Options d'attributions automatique des chambres",
             linkedRoomsTitle: 'Chambres liées',
             linkRooms: 'Lier',
@@ -131,6 +137,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             adminPassPrompt: 'كلمة مرور الإدارة؟',
             adminEnabled: 'تم تفعيل وضع التحرير',
             adminWrongPass: 'كلمة المرور غير صحيحة',
+            configTitle: 'إدارة الإعدادات',
+            roomsTitle: 'الغرف والبداية',
+            exclusionsTitle: 'الاستثناءات',
             adminSectionTitle: 'خيارات التوزيع التلقائي للغرف',
             linkedRoomsTitle: 'الغرف المرتبطة',
             linkRooms: 'ربط',
@@ -157,6 +166,9 @@ document.addEventListener('DOMContentLoaded', async () => {
             clearCalendarBtn,
             adminBtn,
             autoOptionsTitle,
+            configTitle,
+            roomsTitle,
+            exclusionsTitle,
             linkedRoomsTitle,
             addLinkBtn,
             printBtn,

--- a/src/ui.js
+++ b/src/ui.js
@@ -37,6 +37,9 @@ export function applyLanguage(lang, {
   autoAssignBtn,
   clearCalendarBtn,
   adminBtn,
+  configTitle,
+  roomsTitle,
+  exclusionsTitle,
   autoOptionsTitle,
   linkedRoomsTitle,
   addLinkBtn,
@@ -67,6 +70,9 @@ export function applyLanguage(lang, {
   autoAssignBtn.textContent = t.autoAssign;
   clearCalendarBtn.textContent = t.clearCalendar;
   adminBtn.textContent = t.adminLogin;
+  if (configTitle) configTitle.textContent = t.configTitle;
+  if (roomsTitle) roomsTitle.textContent = t.roomsTitle;
+  if (exclusionsTitle) exclusionsTitle.textContent = t.exclusionsTitle;
   if (autoOptionsTitle) autoOptionsTitle.textContent = t.adminSectionTitle;
   if (linkedRoomsTitle) linkedRoomsTitle.textContent = t.linkedRoomsTitle;
   if (addLinkBtn) addLinkBtn.textContent = t.linkRooms;


### PR DESCRIPTION
## Notes
- Ajout d'`id` uniques sur chaque titre de la section admin.
- Déclaration des références DOM correspondantes dans `calendar.js`.
- Extension de l'objet `texts` avec les libellés français et arabes.
- Adaptation de `applyLanguage` pour appliquer ces nouveaux textes.
- Les tests passent via `npm test`.


------
https://chatgpt.com/codex/tasks/task_e_684c296299688324a5a81aa49de90728