### PR TITLE
Fix theme switcher placement

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -153,7 +153,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     function setLanguage(lang) {
         currentLang = lang;
-        return applyLanguage(lang, {
+        const result = applyLanguage(lang, {
             texts,
             monthNamesMap,
             monthSelect,
@@ -181,6 +181,11 @@ document.addEventListener('DOMContentLoaded', async () => {
             populateMonthSelect,
             generateCalendar,
         });
+        if (themeSwitcher) {
+            themeSwitcher.style.right = '10px';
+            themeSwitcher.style.left = 'auto';
+        }
+        return result;
     }
 
     function updateRoomSelectOptions() {

--- a/styles.css
+++ b/styles.css
@@ -112,6 +112,7 @@ button:hover {
     position: fixed;
     top: 10px;
     right: 10px;
+    left: auto;
     z-index: 9999;
     background: var(--header-bg);
     color: var(--text-color);
@@ -129,6 +130,10 @@ button:hover {
     vertical-align: middle;
 }
 html[dir="rtl"] .theme-switcher {
+    right: 10px;
+    left: auto;
+}
+html[dir="ltr"] .theme-switcher {
     right: 10px;
     left: auto;
 }


### PR DESCRIPTION
## Summary
- keep the theme toggle pinned to the top-right by default
- ensure the button position is reset when changing language

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c580ef3d08324ac5e90a0115c209c