### PR TITLE
Corrige position switcher thème

### DIFF
--- a/src/calendar.js
+++ b/src/calendar.js
@@ -181,10 +181,6 @@ document.addEventListener('DOMContentLoaded', async () => {
             populateMonthSelect,
             generateCalendar,
         });
-        if (themeSwitcher) {
-            themeSwitcher.style.right = '10px';
-            themeSwitcher.style.left = 'auto';
-        }
         return result;
     }
 

--- a/styles.css
+++ b/styles.css
@@ -106,7 +106,6 @@ button:hover {
     margin: 10px auto;
 }
 
-}
 
 .theme-switcher {
     position: fixed;


### PR DESCRIPTION
## Résumé
- supprime l'accolade isolée dans `styles.css`
- vérifie que `.theme-switcher` définit bien `right: 10px; left: auto;`
- retire la modification dynamique de position dans `src/calendar.js`

## Test
- `npx jest --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_684dae0331748324816e084d5f67ef82