### PR TITLE
Add RPi4 setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,23 @@ Serveur local recommandé (pour tout voir et modifier) :
 
 ---
 
+### 🐧 Utilisation sur Raspberry Pi 4
+
+Sous Raspberry Pi OS (basé sur Debian 12), l'installation de paquets Python
+dans l'environnement système est restreinte. Pour éviter l'erreur
+`externally-managed-environment`, créez d'abord un environnement virtuel puis
+exécutez le script `setup_gui_rpi4.py` :
+
+```bash
+python3 -m venv ~/env_gui
+source ~/env_gui/bin/activate
+pip install --upgrade pip
+python setup_gui_rpi4.py
+```
+
+Gardez l'environnement activé pour lancer l'application
+(`source ~/env_gui/bin/activate` à chaque session).
+
 ## Configuration
 
 1. Copiez le fichier `.env.example` en `.env`.


### PR DESCRIPTION
## Summary
- explain how to run the RPi4 version using a virtual environment

## Testing
- `npm install`
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_687420803f4883249154382f7cf15802